### PR TITLE
Split ResourceFetchException into multiple exception classes

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,6 +1,6 @@
 name            = ResourceLoader Library
 description     = A loader library for files, uri and resource.
-version         = 2.0.0
+version         = 3.0.0
 
 url             = https://github.com/Akazukin-Team/ResourceLoader-Library
 

--- a/resource/src/main/java/org/akazukin/resource/exception/ResourceNotFoundException.java
+++ b/resource/src/main/java/org/akazukin/resource/exception/ResourceNotFoundException.java
@@ -13,14 +13,20 @@ import org.jetbrains.annotations.Nullable;
  * This exception is often used in conjunction with implementations of the {@link IResourceIdentifier} interface.
  */
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
-public final class ResourceFetchException extends Exception {
-    public static final String MESSAGE = "Failed to fetch the resource;  Identifier:";
-    private static final long serialVersionUID = -966754699305131182L;
+public final class ResourceNotFoundException extends Exception {
+    public static final String MESSAGE = "The requested resource was not found; Identifier:";
+    private static final long serialVersionUID = 6684038629235688862L;
+
     @Getter
     IResourceIdentifier identifier;
 
-    public ResourceFetchException(@NotNull final IResourceIdentifier identifier, @Nullable final Throwable cause) {
+    public ResourceNotFoundException(@NotNull final IResourceIdentifier identifier, @Nullable final Throwable cause) {
         super(MESSAGE + identifier, cause);
+        this.identifier = identifier;
+    }
+
+    public ResourceNotFoundException(@NotNull final IResourceIdentifier identifier) {
+        super(MESSAGE + identifier);
         this.identifier = identifier;
     }
 }

--- a/resource/src/main/java/org/akazukin/resource/identifier/IResourceIdentifier.java
+++ b/resource/src/main/java/org/akazukin/resource/identifier/IResourceIdentifier.java
@@ -1,6 +1,7 @@
 package org.akazukin.resource.identifier;
 
 import org.akazukin.resource.exception.ResourceFetchException;
+import org.akazukin.resource.exception.ResourceNotFoundException;
 import org.akazukin.resource.resource.IResource;
 
 /**
@@ -30,9 +31,10 @@ public interface IResourceIdentifier {
      * The retrieval process may vary based on the specific implementation of the {@link IResourceIdentifier}.
      *
      * @return an instance of {@link IResource} representing the retrieved resource.
-     * @throws ResourceFetchException if the resource cannot be resolved, fetched, or if an error occurs during the retrieval process.
+     * @throws ResourceNotFoundException if the resource cannot be resolved.
+     * @throws ResourceFetchException    if the resource cannot be fetched, or if an error occurs during the retrieval process.
      */
-    IResource getResource() throws ResourceFetchException;
+    IResource getResource() throws ResourceNotFoundException, ResourceFetchException;
 
     @Override
     String toString();

--- a/resource/src/main/java/org/akazukin/resource/identifier/PathResourceIdentifier.java
+++ b/resource/src/main/java/org/akazukin/resource/identifier/PathResourceIdentifier.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.experimental.FieldDefaults;
 import org.akazukin.resource.exception.ResourceFetchException;
+import org.akazukin.resource.exception.ResourceNotFoundException;
 import org.akazukin.resource.resource.IResource;
 import org.akazukin.resource.resource.PathResource;
 
@@ -33,19 +34,18 @@ public final class PathResourceIdentifier implements IResourceIdentifier {
     }
 
     @Override
-    public IResource getResource() throws ResourceFetchException {
+    public IResource getResource() throws ResourceNotFoundException, ResourceFetchException {
         try {
             final Path path = Paths.get(this.identifier);
             if (!path.toFile().exists()) {
-                throw new ResourceFetchException(ResourceFetchException.Type.NOT_FOUND, this);
+                throw new ResourceNotFoundException(this);
             }
 
             return new PathResource(this);
+        } catch (final ResourceNotFoundException e) {
+            throw e;
         } catch (final Throwable t) {
-            if (t instanceof ResourceFetchException) {
-                throw (ResourceFetchException) t;
-            }
-            throw new ResourceFetchException(ResourceFetchException.Type.FETCH_ERROR, t, this);
+            throw new ResourceFetchException(this, t);
         }
     }
 

--- a/resource/src/main/java/org/akazukin/resource/identifier/ResourceResourceIdentifier.java
+++ b/resource/src/main/java/org/akazukin/resource/identifier/ResourceResourceIdentifier.java
@@ -3,7 +3,6 @@ package org.akazukin.resource.identifier;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.experimental.FieldDefaults;
-import org.akazukin.resource.exception.ResourceFetchException;
 import org.akazukin.resource.resource.IResource;
 import org.akazukin.resource.resource.ResourceResource;
 
@@ -39,11 +38,7 @@ public final class ResourceResourceIdentifier implements IResourceIdentifier {
     }
 
     @Override
-    public IResource getResource() throws ResourceFetchException {
-        try {
-            return new ResourceResource(this);
-        } catch (final Throwable t) {
-            throw new ResourceFetchException(ResourceFetchException.Type.FETCH_ERROR, t, this);
-        }
+    public IResource getResource() {
+        return new ResourceResource(this);
     }
 }

--- a/resource/src/main/java/org/akazukin/resource/identifier/UriResourceIdentifier.java
+++ b/resource/src/main/java/org/akazukin/resource/identifier/UriResourceIdentifier.java
@@ -44,8 +44,8 @@ public class UriResourceIdentifier implements IResourceIdentifier {
 
             if (this.ssl) {
                 if (!(con instanceof javax.net.ssl.HttpsURLConnection)) {
-                    throw new ResourceFetchException(ResourceFetchException.Type.FETCH_ERROR,
-                            new IllegalArgumentException("SSL is enabled but the connection is not HTTPS"), this);
+                    throw new ResourceFetchException(this,
+                            new IllegalArgumentException("SSL is enabled but the connection is not HTTPS"));
                 } else {
                     ((javax.net.ssl.HttpsURLConnection) con).setSSLSocketFactory(this.createSocketFactory());
                 }
@@ -58,11 +58,13 @@ public class UriResourceIdentifier implements IResourceIdentifier {
             con.connect();
 
             return new UriResource(this, con);
+        } catch (final ResourceFetchException e) {
+            throw e;
         } catch (final Throwable t) {
             if (con != null) {
                 con.disconnect();
             }
-            throw new ResourceFetchException(ResourceFetchException.Type.FETCH_ERROR, t, this);
+            throw new ResourceFetchException(this, t);
         }
     }
 

--- a/resource/src/main/java/org/akazukin/resource/resource/IResource.java
+++ b/resource/src/main/java/org/akazukin/resource/resource/IResource.java
@@ -1,6 +1,7 @@
 package org.akazukin.resource.resource;
 
 import org.akazukin.resource.exception.ResourceFetchException;
+import org.akazukin.resource.exception.ResourceNotFoundException;
 import org.akazukin.resource.identifier.IResourceIdentifier;
 
 import java.io.Closeable;
@@ -35,7 +36,7 @@ public interface IResource extends Closeable {
      * @throws UnsupportedOperationException if the resource implementation does not support input streams.
      * @throws IllegalStateException         if the input stream is already closed or not available.
      */
-    InputStream getInputStream() throws ResourceFetchException;
+    InputStream getInputStream() throws ResourceNotFoundException, ResourceFetchException;
 
     /**
      * Provides an {@link OutputStream} for writing data to the resource.
@@ -44,7 +45,7 @@ public interface IResource extends Closeable {
      * @throws UnsupportedOperationException if the resource implementation does not support output streams.
      * @throws IllegalStateException         if the output stream is already closed or not available.
      */
-    OutputStream getOutputStream() throws ResourceFetchException;
+    OutputStream getOutputStream() throws ResourceNotFoundException, ResourceFetchException;
 
     @Override
     default void close() {

--- a/resource/src/main/java/org/akazukin/resource/resource/PathResource.java
+++ b/resource/src/main/java/org/akazukin/resource/resource/PathResource.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import org.akazukin.resource.exception.ResourceFetchException;
+import org.akazukin.resource.exception.ResourceNotFoundException;
 import org.akazukin.resource.identifier.PathResourceIdentifier;
 
 import java.io.InputStream;
@@ -29,32 +30,32 @@ public class PathResource implements IResource {
     }
 
     @Override
-    public InputStream getInputStream() throws ResourceFetchException {
+    public InputStream getInputStream() throws ResourceNotFoundException, ResourceFetchException {
         final Path path = Paths.get(this.identifier.getIdentifier());
         if (!path.toFile().exists()) {
-            throw new ResourceFetchException(ResourceFetchException.Type.NOT_FOUND, this.getIdentifier());
+            throw new ResourceNotFoundException(this.getIdentifier());
         }
 
         try {
             return Files.newInputStream(path);
-        } catch (final Throwable e) {
-            log.error("Failed to get input stream for resource: {}", this.getIdentifier(), e);
-            throw new ResourceFetchException(ResourceFetchException.Type.FETCH_ERROR, e, this.getIdentifier());
+        } catch (final Throwable t) {
+            log.error("Failed to get input stream for resource: {}", this.getIdentifier(), t);
+            throw new ResourceFetchException(this.getIdentifier(), t);
         }
     }
 
     @Override
-    public OutputStream getOutputStream() throws ResourceFetchException {
+    public OutputStream getOutputStream() throws ResourceNotFoundException, ResourceFetchException {
         final Path path = Paths.get(this.identifier.getIdentifier());
         if (!path.toFile().exists()) {
-            throw new ResourceFetchException(ResourceFetchException.Type.NOT_FOUND, this.getIdentifier());
+            throw new ResourceNotFoundException(this.getIdentifier());
         }
 
         try {
             return Files.newOutputStream(path);
-        } catch (final Throwable e) {
-            log.error("Failed to get output stream for resource: {}", this.getIdentifier(), e);
-            throw new ResourceFetchException(ResourceFetchException.Type.FETCH_ERROR, e, this.getIdentifier());
+        } catch (final Throwable t) {
+            log.error("Failed to get output stream for resource: {}", this.getIdentifier(), t);
+            throw new ResourceFetchException(this.getIdentifier(), t);
         }
     }
 }

--- a/resource/src/main/java/org/akazukin/resource/resource/ResourceResource.java
+++ b/resource/src/main/java/org/akazukin/resource/resource/ResourceResource.java
@@ -4,7 +4,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
-import org.akazukin.resource.exception.ResourceFetchException;
+import org.akazukin.resource.exception.ResourceNotFoundException;
 import org.akazukin.resource.identifier.ResourceResourceIdentifier;
 
 import java.io.InputStream;
@@ -28,10 +28,10 @@ public class ResourceResource implements IResource {
     }
 
     @Override
-    public InputStream getInputStream() throws ResourceFetchException {
+    public InputStream getInputStream() throws ResourceNotFoundException {
         final InputStream is = this.identifier.getClassLoader().getResourceAsStream(this.getIdentifier().getIdentifier());
         if (is == null) {
-            throw new ResourceFetchException(ResourceFetchException.Type.NOT_FOUND, this.identifier);
+            throw new ResourceNotFoundException(this.identifier);
         }
         return is;
     }

--- a/resource/src/main/java/org/akazukin/resource/resource/UriResource.java
+++ b/resource/src/main/java/org/akazukin/resource/resource/UriResource.java
@@ -5,8 +5,10 @@ import lombok.Getter;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import org.akazukin.resource.exception.ResourceFetchException;
+import org.akazukin.resource.exception.ResourceNotFoundException;
 import org.akazukin.resource.identifier.UriResourceIdentifier;
 
+import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
@@ -29,12 +31,14 @@ public class UriResource implements IResource {
     }
 
     @Override
-    public InputStream getInputStream() throws ResourceFetchException {
+    public InputStream getInputStream() throws ResourceFetchException, ResourceNotFoundException {
         try {
             return this.connection.getInputStream();
-        } catch (final Throwable e) {
-            log.error("Failed to get input stream for resource: {}", this.getIdentifier(), e);
-            throw new ResourceFetchException(ResourceFetchException.Type.FETCH_ERROR, e, this.getIdentifier());
+        } catch (final FileNotFoundException e) {
+            throw new ResourceNotFoundException(this.getIdentifier(), e);
+        } catch (final Throwable t) {
+            log.error("Failed to get input stream for resource: {}", this.getIdentifier(), t);
+            throw new ResourceFetchException(this.getIdentifier(), t);
         }
     }
 
@@ -42,9 +46,9 @@ public class UriResource implements IResource {
     public OutputStream getOutputStream() throws ResourceFetchException {
         try {
             return this.connection.getOutputStream();
-        } catch (final Throwable e) {
-            log.error("Failed to get output stream for resource: {}", this.getIdentifier(), e);
-            throw new ResourceFetchException(ResourceFetchException.Type.FETCH_ERROR, e, this.getIdentifier());
+        } catch (final Throwable t) {
+            log.error("Failed to get output stream for resource: {}", this.getIdentifier(), t);
+            throw new ResourceFetchException(this.getIdentifier(), t);
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to contribute 🙌 -->
<!-- Pull request titles must be in English. -->

#### What kind of changes does this PR include?

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ ] Minor content fixes (broken links, typos, exceptions, etc.)
- [x] New or updated content
- [ ] Documentation updates
- [ ] Assets content
- [x] Code refactoring
- [ ] Dependency updates
- [ ] Build Logic updates
- [ ] Other

---

#### Description

<!--
Did you make any visual changes? If so, a screenshot or video would be helpful.
-->

- Introduced `ResourceNotFoundException` to separate concerns for not-found scenarios.
- Simplified `ResourceFetchException` by removing nested `Type` enum and unused constructors.
- Updated relevant methods across identifiers and resources to align with new exception hierarchy.
- Improved error clarity and handling.<!-- Please provide a brief summary of the changes introduced by this PR. -->

---

## Does this PR introduce a breaking change?

<!--
We prefer to avoid breaking changes.
We will only accept PRs with breaking changes if they have been discussed in an issue first.

Please check one of the boxes below to indicate if this PR introduces a breaking change.
-->

- [x] Yes
- [ ] No

---

## Additional Notes

- <!-- If there's anything else you want to add, mention it here. -->

---

## Related Issue or PR

- <!-- Add an issue or PR number if this PR is related to one. -->

<!--
If you are suggesting a new feature or change, please discuss it in an issue first.
If you are fixing a bug, there should be an issue describing it using a bug report template.
-->

---

<!--
Please keep your changes minimal and focused.
Pull requests with redundant code may be rejected.

If you create new classes or methods, adding documentation is appreciated.
-->
